### PR TITLE
Edit Movies from Menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,28 +207,19 @@ class App extends React.Component {
     if(this.state.formsTitle === "Edit Movie")
     {
       console.log("Edit Movie")
-      axios.put(cors + heliumApi + 'movies', values).then(response => {
-        console.log(response)
-      })
+      axios.put(cors + heliumApi + 'movies/' + values.id, values)
+      .then(action => {this.setState({ postSuccessAlert: true, formsDialog: false, snackBarMessage:"Edited " + values.title})})
       .catch(error => {console.log(error.response)})
+      this.setState({ movies: this.state.movies.filter(items => items.movieId != values.id)});
     }
 
     // if adding a new movie, performs axios post
     else {
       axios.post(cors + heliumApi + 'movies', values)
-      .then(action => this.setState({ postSuccessAlert: true, formsDialog: false, snackBarMessage: values.title}))
+      .then(action => this.setState({ postSuccessAlert: true, formsDialog: false, snackBarMessage:"Added " + values.title}))
       .catch(error => {console.log(error.response)})
     }
-    console.log(values);
 
-    // axios.post(cors + heliumApi + 'movies', values)
-    //   .then(action => this.setState({ postSuccessAlert: true, formsDialog: false}))
-    //   .catch(error => {console.log(error.response)})
-
-  }
-
-  handleSearch = (searchInput: string) => {
-    console.log("oh");
   }
 
   render() { 
@@ -388,7 +379,7 @@ class App extends React.Component {
           horizontal: 'center',
         }}
         open={this.state.postSuccessAlert}
-        message={<span id="postSuccessMessage">Added {this.state.snackBarMessage}</span>}
+        message={<span id="postSuccessMessage">{this.state.snackBarMessage}</span>}
         action={[<IconButton onClick={() => this.setState({postSuccessAlert: false, formsDialog: false })}><CloseIcon color="primary" /></IconButton>]} />
       <Snackbar
         className="postFailureAlert"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import {
   DialogContentText,
 } from '@material-ui/core';
 import './App.css';
-import { Formik, Field, Form, FormikProps, setNestedObjectValues, FormikActions, FormikProvider } from 'formik';
+import { Formik, Field, Form, FormikProps, FormikActions } from 'formik';
 import { TextField } from 'formik-material-ui';
 import Snackbar from '@material-ui/core/Snackbar';
 import ApplicationBar from './components/applicationBar';
@@ -44,6 +44,7 @@ interface IState {
   filteredMovies: [];
   deleteId: string,
   editMovieInput: Movie,
+  movieRoles: string[],
 }
 
 interface IProps {
@@ -69,6 +70,7 @@ class App extends React.Component {
     filteredMovies: [],
     deleteId: '',
     editMovieInput: {id: '', year: '', runtime: 0, type: 'Movie', title: '', textSearch: '', roles: [], movieId: '', genres: [], key: '0',},
+    movieRoles: [],
   };
 
   componentDidMount() {
@@ -125,7 +127,7 @@ class App extends React.Component {
 
      if(dMovies.length > 0) {
       let i: number, temp: any;
-      for(let i = 0; i < dMovies.length; i ++ ) {
+      for(i = 0; i < dMovies.length; i ++ ) {
         console.log(dMovies[i]);
         axios.delete(cors + heliumApi + 'movies/' + dMovies[i])
         .then((response: any) => { console.log(response.data);})
@@ -143,13 +145,14 @@ class App extends React.Component {
         .then((response: any) => { console.log(response.data);})
         .catch(error => { console.log(error);})
         this.setState({
-          movies: this.state.movies.filter(items => items.movieId != id)
+          movies: this.state.movies.filter(items => items.movieId !== id)
         });
      }
   }
 
   // edits an existing movie on menu "edit" button click
   editMovie = (movie: Movie) => {
+    this.setState({formsTitle: "Edit Movie", formsDialog: true, movieRoles: movie.roles})
     this.setState({editMovieInput: {
       title: movie.title,
       year: movie.year,
@@ -161,7 +164,8 @@ class App extends React.Component {
       id: movie.movieId,
       type: movie.type,
       key: '0'
-    }, formsTitle: "Edit Movie", formsDialog: true})
+    }})
+    console.log(this.state.movieRoles)
   }
 
   deleteMultipleMovies = () => {
@@ -216,7 +220,7 @@ class App extends React.Component {
       axios.put(cors + heliumApi + 'movies/' + values.id, values)
       .then(action => {this.handleEdit(values)})
       .catch(error => {console.log(error.response)})
-      this.setState({movies: this.state.movies.filter(items => items.movieId != this.state.editMovieInput.movieId )})
+      this.setState({movies: this.state.movies.filter(items => items.movieId !== this.state.editMovieInput.movieId )})
 
     }
 
@@ -227,14 +231,12 @@ class App extends React.Component {
       .then(action => this.setState({ postSuccessAlert: true, formsDialog: false, snackBarMessage:"Added " + values.title}))
       .catch(error => {console.log(error.response)})
       this.setState({
-        movies: this.state.movies.map(items => items.movieId == values.movieId)
+        movies: this.state.movies.map(items => items.movieId === values.movieId)
       });
     }
   }
 
   render() { 
-    const { anchorEl } = this.state;
-
     return (
       <React.Fragment>
       <ApplicationBar handleSearchChange={this.searchToggle}/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,6 @@ import ApplicationBar from './components/applicationBar';
 import MovieCard from './components/movieComp';
 import { Movie, Actor, Genre } from './models/models';
 import * as Yup from 'yup';
-import { DEFAULT_ENCODING } from 'crypto';
-import { any } from 'prop-types';
-import { Z_FILTERED } from 'zlib';
 
 const heliumApi = 'https://heliumint.azurewebsites.net/api/';
 const cors = 'https://cors-anywhere.herokuapp.com/';
@@ -103,9 +100,6 @@ class App extends React.Component {
     .catch(error => {
       console.log(error);
     });
-  }
-
-  componentDidUpdate() {
   }
 
   searchToggle = (searchInput: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -235,22 +235,17 @@ class App extends React.Component {
     }
 
     // if adding a new movie, performs axios post
-    else {
-      console.log(values)
+    if(this.state.formsTitle === "Add Movie") {
+      let movies = this.state.movies;
       axios.post(cors + heliumApi + 'movies', values)
       .then(action => this.setState({ postSuccessAlert: true, formsDialog: false, snackBarMessage:"Added " + values.title}))
       .catch(error => {console.log(error.response)})
-      this.setState({
-        movies: this.state.movies.map(items => items.movieId === values.movieId)
-      });
+      movies.push(values);
+      this.setState({movies})
     }
   }
 
-  sort() {
-
-  }
   render() { 
-    
     return (
       <React.Fragment>
       <ApplicationBar handleSearchChange={this.searchToggle}/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,18 @@ class App extends React.Component {
 
   // edits an existing movie on menu "edit" button click
   editMovie = (movie: Movie) => {
-    this.setState({editMovieInput: movie, formsDialog: true, formsTitle:"Edit Movie"});
+    this.setState({editMovieInput: {
+      title: movie.title,
+      year: movie.year,
+      runtime: movie.runtime,
+      textSearch: movie.title.toLowerCase(),
+      roles: '',
+      genres: movie.genres,
+      movieId: movie.movieId,
+      id: movie.movieId,
+      type: movie.type,
+      key: '0'
+    }, formsTitle: "Edit Movie", formsDialog: true})
   }
 
   deleteMultipleMovies = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,7 +207,6 @@ class App extends React.Component {
     console.log("temp " + temp.title)
     this.setState({snackBarMessage: "Edited " + this.state.editMovieInput.title + " to " + values.title, formsDialog: false, postSuccessAlert: true});
   
-    // movies.push(values);
     movies.push({
       title: values.title,
       year: values.year,
@@ -233,7 +232,6 @@ class App extends React.Component {
       .then(action => {this.handleEdit(values)})
       .catch(error => {console.log(error.response)})
       this.setState({movies: this.state.movies.filter(items => items.movieId !== this.state.editMovieInput.movieId )})
-
     }
 
     // if adding a new movie, performs axios post
@@ -248,13 +246,27 @@ class App extends React.Component {
     }
   }
 
+  sort() {
+
+  }
   render() { 
+    
     return (
       <React.Fragment>
       <ApplicationBar handleSearchChange={this.searchToggle}/>
       <main> 
       <Grid container spacing={8}>           
-          {this.state.movies.map((item, i) => (
+          {this.state.movies
+            .sort(function(a,b) {
+              if(a.title.toLowerCase() < b.title.toLowerCase()) {
+                return -1
+              }
+              if (a.title.toLowerCase() > b.title.toLowerCase()) {
+                return 1
+              }
+              return 0
+            })
+            .map((item, i) => (
             <Grid item key={item.movieId} sm={6} md={4} lg={3}>
               <MovieCard toggleCheck={this.checkBoxToggle} deleteMovie={this.deleteMovieConfirm} editMovie={this.editMovie} movie={item}/>
             </Grid>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,7 +207,19 @@ class App extends React.Component {
     console.log("temp " + temp.title)
     this.setState({snackBarMessage: "Edited " + this.state.editMovieInput.title + " to " + values.title, formsDialog: false, postSuccessAlert: true});
   
-    movies.push(values);
+    // movies.push(values);
+    movies.push({
+      title: values.title,
+      year: values.year,
+      runtime: values.runtime,
+      textSearch: values.title.toLowerCase(),
+      roles: this.state.movieRoles,
+      genres: values.genres,
+      movieId: values.movieId,
+      id: values.movieId,
+      type: values.type,
+      key: values.key,
+    })
     this.setState({movies});
   }
 

--- a/src/components/movieComp.tsx
+++ b/src/components/movieComp.tsx
@@ -64,8 +64,6 @@ class movieComp extends React.Component<IProps> {
     deleteMovie = (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
         console.log("delete " + this.state.movie.movieId);
         this.props.deleteMovie(this.state.movie.movieId, this.state.movie.title);
-        // console.log("delete " + this.state.movie);
-        // this.props.deleteMovie(this.state.movie);
     }
 
     editMovie = (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
@@ -81,44 +79,40 @@ class movieComp extends React.Component<IProps> {
     render() {  
         return (
             <div>
-                <Card>
-                <CardHeader 
-                    title = {this.state.movie.title.substring(0,30)}
-                    action = {
-                        <IconButton 
-                          onClick={this.handleMenuClick}
-                          aria-owns={this.state.anchorEl ? 'cardMenu' : undefined}
-                          aria-haspopup="true" >
-                          <MoreVertIcon />
-                        </IconButton> } />
-                <CardMedia
-                  style={{height: 0, paddingTop: '56.25%'}}
-                  image={MoviePH}
-                  title="img"/>
-                <CardContent>
-                    <Typography>
-                        Year: {this.state.movie.year}<br />
-                        Runtime: {this.state.movie.runtime}min <br />
-                        Genres: {this.joinStr(this.state.movie.genres)}<br />
-                    </Typography>
-                    <Typography>
-                        Roles: {this.state.movie.key}
-                    </Typography>
-                </CardContent>
-                <CardActions>
-                    {/* <Typography color="primary">Delete</Typography> */}
-                    <Checkbox color="primary" checked={this.state.checkedBox} onChange={this.toggleCheck}/>
-                </CardActions>
-                </Card>
-                <Menu
-                    id="cardMenu"
-                    anchorEl={this.state.anchorEl}
-                    open={Boolean(this.state.anchorEl)}
-                    onClose={() => this.setState({ anchorEl: null })} >
-                    <MenuItem onClick={(this.deleteMovie)}>Delete</MenuItem>
-                    <MenuItem onClick={(this.editMovie)}>Edit</MenuItem>
-                </Menu>  
-            </div>
+            <Card>
+            <CardHeader 
+                title = {this.state.movie.title.substring(0,30)}
+                action = {
+                    <IconButton 
+                        onClick={this.handleMenuClick}
+                        aria-owns={this.state.anchorEl ? 'cardMenu' : undefined}
+                        aria-haspopup="true" >
+                        <MoreVertIcon />
+                    </IconButton> } />
+            <CardMedia
+                style={{height: 0, paddingTop: '56.25%'}}
+                image={MoviePH}
+                title="img"/>
+            <CardContent>
+                <Typography>
+                    Year: {this.state.movie.year}<br />
+                    Runtime: {this.state.movie.runtime}min <br />
+                    Genres: {this.joinStr(this.state.movie.genres)}<br />
+                </Typography>
+            </CardContent>
+            <CardActions>
+                <Checkbox color="primary" checked={this.state.checkedBox} onChange={this.toggleCheck}/>
+            </CardActions>
+            </Card>
+            <Menu
+                id="cardMenu"
+                anchorEl={this.state.anchorEl}
+                open={Boolean(this.state.anchorEl)}
+                onClose={() => this.setState({ anchorEl: null })} >
+                <MenuItem onClick={(this.deleteMovie)}>Delete</MenuItem>
+                <MenuItem onClick={(this.editMovie)}>Edit</MenuItem>
+            </Menu>  
+        </div>
         )
     }
 }

--- a/src/components/movieComp.tsx
+++ b/src/components/movieComp.tsx
@@ -1,7 +1,5 @@
 import React, {Component} from 'react'; 
-import MoviePH from "../imgs/movieplaceholder.jpg";
-import PropTypes from 'prop-types';
-import {
+import MoviePH from "../imgs/movieplaceholder.jpg";import {
     Card,
     CardActions,
     CardContent,
@@ -14,7 +12,6 @@ import {
     Typography,
   } from '@material-ui/core';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
-import App from '../App';
 import { Movie } from '../models/models';
 
 interface IState {
@@ -52,7 +49,6 @@ class movieComp extends React.Component<IProps> {
             requiredField: false,
         };
     }
-
 
     joinStr(list: string[]): string {
         if (list && list instanceof Array) {
@@ -94,9 +90,7 @@ class movieComp extends React.Component<IProps> {
                           aria-owns={this.state.anchorEl ? 'cardMenu' : undefined}
                           aria-haspopup="true" >
                           <MoreVertIcon />
-                        </IconButton>
-                      }
-                    />
+                        </IconButton> } />
                 <CardMedia
                   style={{height: 0, paddingTop: '56.25%'}}
                   image={MoviePH}
@@ -106,7 +100,9 @@ class movieComp extends React.Component<IProps> {
                         Year: {this.state.movie.year}<br />
                         Runtime: {this.state.movie.runtime}min <br />
                         Genres: {this.joinStr(this.state.movie.genres)}<br />
-                        Key: {this.state.movie.key}<br />
+                    </Typography>
+                    <Typography>
+                        Roles: {this.state.movie.key}
                     </Typography>
                 </CardContent>
                 <CardActions>


### PR DESCRIPTION
Addresses issue [#187](https://github.com/microsoft/helium/issues/187)

- On Edit Menu Item clicked, new forms dialog is brought up
- Forms Dialog successfully calls Axios.put and allows user to edit the movie card with pre-populated data from the existing movie.
- Filters out old movie id from the list, and snackbar notification confirms "edited movie from old name to new name"
- Adds edited movie card to the bottom of the list


In Addition...
- auto populates key, textsearch, and id to temporary solve issue [# 221](https://github.com/microsoft/helium/issues/221)
- sets roles as an empty string so "object object" doesn't populate in the UI form. Resets values to roles on submit so data doesn't disappear 