### PR TITLE
Fixing POST by passing correct values for refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,9 +238,9 @@ class App extends React.Component {
     // if adding a new movie, performs axios post
     if(this.state.formsTitle === "Add Movie") {
       axios.post(cors + heliumApi + 'movies', subMovie)
-      .then(action => this.setState({ postSuccessAlert: true, openForms: false, snackBarMessage:"Added " + values.title}))
+      .then(action => this.setState({ postSuccessAlert: true, openForms: false, snackBarMessage:"Added " + subMovie.title}))
       .catch(error => {console.log(error.response)})
-      movies.push(values);
+      movies.push(subMovie);
       this.setState({movies})
     }
   }


### PR DESCRIPTION
Before, was using _values_ for snackbar confirmation and pushing new movie to state on a new POST.

Changed _values_ -> _submovie_. This way, it will include all fields that are not displayed on the front end, as well as genres and roles properly when implemented. 